### PR TITLE
Update 29_StripOnlyUnequips.rb for 0.10.2

### DIFF
--- a/Framework/othermods/29_StripOnlyUnequips.rb
+++ b/Framework/othermods/29_StripOnlyUnequips.rb
@@ -1,17 +1,15 @@
 module GIM_CHCG
-  def combat_remove_random_equip(eqp_target=rand(10),summon=true)
-    return if !equip_slot_removetable?(eqp_target)
-    #is_a?(String)
-    tar_name = $game_player.actor.equips[eqp_target].item_name
-    $game_player.actor.change_equip(eqp_target, nil)
-    tarType = eqp_target==0 ? "Weapon" : "Armor"
-    # $game_party.drop_tgt_item_and_summon(tarType,tar_name,1,summon)
-    if [0,1].include?(eqp_target) && summon
-      SndLib.sound_combat_sword_hit_sword(vol=80,effect=65+rand(10))
-    else
-      SndLib.sound_DressTear(vol=80,effect=75+rand(10))
-    end
-    $game_player.actor.update_state_frames
-    $game_player.update
-  end #def  
+  def combat_remove_random_equip_exec(tar_name,eqp_target=rand(10),summon=true)
+		$game_player.actor.change_equip(eqp_target, nil)
+		weaponSlots = System_Settings::EQUIP::WEAPON_SLOTS
+		tarType = weaponSlots.include?(eqp_target) ? "Weapon" : "Armor"
+		#$game_party.drop_tgt_item_and_summon(tarType,tar_name,1,summon)
+		if weaponSlots.include?(eqp_target) && summon
+			SndLib.sound_combat_sword_hit_sword(vol=80,effect=65+rand(10))
+		else
+			SndLib.sound_DressTear(vol=80,effect=75+rand(10))
+		end
+		$game_player.actor.update_state_frames
+		$game_player.update
+	end #def
 end


### PR DESCRIPTION
New version of game redirects combat_remove_random_equip to combat_remove_random_equip_exec. Used original code of combat_remove_random_equip_exec, just commented out drop/spawn step.